### PR TITLE
VOER-1817: Added stdlib.h to support EXIT_FAILURE macro on aarch64.

### DIFF
--- a/dpdk_mac_resolver/dpdk_mac_resolver.c
+++ b/dpdk_mac_resolver/dpdk_mac_resolver.c
@@ -12,6 +12,7 @@
 #include <sys/types.h>
 #include <sys/socket.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdint.h>
 #include <inttypes.h>
 #include <unistd.h>


### PR DESCRIPTION
Before: 
```
root@linuxbox:/opt/dpdk-utils/dpdk_mac_resolver# ninja -C build install
ninja: Entering directory `build'
[1/3] Compiling C object 'dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o'.
FAILED: dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o
ccache cc -Idpdk-mac-resolver@exe -I. -I.. -I/usr/local/include -I/usr/include/libnl3 -fdiagnostics-color=always -pipe -D_FILE_OFFSET_BITS=64 -Wall -Winvalid-pch -std=gnu11 -g -include rte_config.h -march=armv8-a+crc -moutline-atomics -MD -MQ 'dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o' -MF 'dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o.d' -o 'dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o' -c ../dpdk_mac_resolver.c
../dpdk_mac_resolver.c: In function 'log_hex_dump':
../dpdk_mac_resolver.c:63:2: warning: implicit declaration of function 'rte_hexdump'; did you mean 'log_hex_dump'? [-Wimplicit-function-declaration]
   63 |  rte_hexdump(stdout, msg, rte_pktmbuf_mtod(mbuf, void*), rte_pktmbuf_pkt_len(mbuf));
      |  ^~~~~~~~~~~
      |  log_hex_dump
../dpdk_mac_resolver.c: In function 'send_ndp_request':
../dpdk_mac_resolver.c:267:12: error: 'EXIT_FAILURE' undeclared (first use in this function)
  267 |   rte_exit(EXIT_FAILURE, "Invalid source MAC address: %s\n", src_mac_str);
      |            ^~~~~~~~~~~~
../dpdk_mac_resolver.c:267:12: note: each undeclared identifier is reported only once for each function it appears in
../dpdk_mac_resolver.c: In function 'main':
../dpdk_mac_resolver.c:351:15: warning: implicit declaration of function 'atoi' [-Wimplicit-function-declaration]
  351 |     retries = atoi(argv[i + 1]);
      |               ^~~~
../dpdk_mac_resolver.c:372:12: error: 'EXIT_FAILURE' undeclared (first use in this function)
  372 |   rte_exit(EXIT_FAILURE, "Error with EAL initialization\n");
      |            ^~~~~~~~~~~~
ninja: build stopped: subcommand failed.
root@linuxbox:/opt/dpdk-utils/dpdk_mac_resolver#
```

Now:
```
root@linuxbox:/opt/dpdk-utils/dpdk_mac_resolver# ninja -C build install
ninja: Entering directory `build'
[1/3] Compiling C object 'dpdk-mac-resolver@exe/dpdk_mac_resolver.c.o'.
../dpdk_mac_resolver.c: In function 'log_hex_dump':
../dpdk_mac_resolver.c:64:2: warning: implicit declaration of function 'rte_hexdump'; did you mean 'log_hex_dump'? [-Wimplicit-function-declaration]
   64 |  rte_hexdump(stdout, msg, rte_pktmbuf_mtod(mbuf, void*), rte_pktmbuf_pkt_len(mbuf));
      |  ^~~~~~~~~~~
      |  log_hex_dump
[2/3] Installing files.
Installing dpdk-mac-resolver to /usr/local/bin
root@linuxbox:/opt/dpdk-utils/dpdk_mac_resolver#
```